### PR TITLE
lazy bind $compositionMode

### DIFF
--- a/src/PHPixie/Image/Drivers/Type/Gmagick/Resource.php
+++ b/src/PHPixie/Image/Drivers/Type/Gmagick/Resource.php
@@ -19,12 +19,14 @@ class Resource extends \PHPixie\Image\Drivers\Type\Imagick\Resource
 	 */
 	protected $drawClass  = '\GmagickDraw';
 
-	/**
-	 * Composition mode
-	 * @var int
-	 */
-	protected $compositionMode =  \Gmagick::COMPOSITE_OVER;
-    
+    public function __construct($image, $width, $height)
+    {
+        parent::__construct($image, $width, $height);
+        if (class_exists('\Gmagick', false)) {
+            $this->compositionMode = \Gmagick::COMPOSITE_OVER;
+        }
+    }
+
     protected function setQuality($quality) {
         $this->image->setCompressionQuality($quality);
     }

--- a/src/PHPixie/Image/Drivers/Type/Imagick/Resource.php
+++ b/src/PHPixie/Image/Drivers/Type/Imagick/Resource.php
@@ -29,12 +29,15 @@ class Resource extends \PHPixie\Image\Drivers\Driver\Resource
 	 * Composition mode
 	 * @var int
 	 */
-	protected $compositionMode =  \Imagick::COMPOSITE_OVER;
+	protected $compositionMode;
 
     public function __construct($image, $width, $height)
     {
         $this->image = $image;
         $this->updateSize($width, $height);
+        if (class_exists('\Imagick', false)) {
+            $this->compositionMode = \Imagick::COMPOSITE_OVER;
+        }
     }
 
 	/**


### PR DESCRIPTION
If you want to use this library with gmagick only, it tries to autoload `\Imagick` as a value for `$compositionMode` in the Imagick Resource.

Changed this to a late binding in each constructor by actually checking for the existing class.